### PR TITLE
fix incorrect basescan URI in console log statement

### DIFF
--- a/tutorial-2.ts
+++ b/tutorial-2.ts
@@ -65,7 +65,7 @@ const smartAccountClient = createSmartAccountClient({
 });
 
 console.log(
-	`Smart account address: https://sepolia.basescan.io/address/${account.address}`,
+	`Smart account address: https://sepolia.basescan.org/address/${account.address}`,
 );
 
 const senderUsdcBalance = await publicClient.readContract({


### PR DESCRIPTION
Going through the tutorial I noticed that the basescan URI was pointing to the wrong domain.